### PR TITLE
Feature: Add daily packs

### DIFF
--- a/commands/game/shop.js
+++ b/commands/game/shop.js
@@ -136,9 +136,9 @@ module.exports = {
         }
       } else {
         if (dailyPack_isBig) {
-          dailyPack_description += `:asterisk: :asterisk: Common ${classes[dailyPack_class].name} x2\n❓ :asterisk: :asterisk: Random Common x2`;
+          dailyPack_description += `:asterisk: :asterisk: Common ${classes[dailyPack_class].name} x2\n❓: :asterisk: :asterisk: Random Common x2`;
         } else {
-          dailyPack_description += `:asterisk: :asterisk: Common ${classes[dailyPack_class].name} x2\n❓ :asterisk: Random Common x1`;
+          dailyPack_description += `:asterisk: :asterisk: Common ${classes[dailyPack_class].name} x2\n❓: :asterisk: Random Common x1`;
         }
       }
       if (dailyPack_hasSpecial) {


### PR DESCRIPTION
Adds daily packs to the shop; they refresh alongside the daily emojis. Tested and works on private instance.

The main feature of daily packs is that they give mostly emojis of one class that changes daily. They vary in specific contents, so some will give rares, others will give commons, some will give a special alongside the main offerings. They also vary slightly in price, so there is some strategy for which packs to pick up and which to leave.

The shopkeeper also has a new quote for the daily pack!

There are constants at the top of the file so you can tweak values as needed.

Also includes a fix to rendering for buy-one -- now it is the same as buy-more, which fixes unpleasant rendering.

_These screenshots don't have the custom emojis since I don't have the assets to add them to my test bot._
<img width="377" height="407" alt="image" src="https://github.com/user-attachments/assets/0342dc94-2cd2-4088-925c-5c8d4477b1ba" />
<img width="360" height="250" alt="image" src="https://github.com/user-attachments/assets/b8d70355-1b2f-4934-85f3-36d6f6337869" />
<img width="254" height="170" alt="image" src="https://github.com/user-attachments/assets/68b32d01-a440-4115-bd4f-3653abbdd92c" />
<img width="468" height="655" alt="image" src="https://github.com/user-attachments/assets/e2de2027-62df-4ea9-b169-adec2b88b646" />

Thank you! :)